### PR TITLE
change rounding for distances under 1mi/1km

### DIFF
--- a/Leaflet.Measurable.js
+++ b/Leaflet.Measurable.js
@@ -44,14 +44,14 @@ L.GeoUtil = L.extend(L.GeoUtil || {}, {
         if (unit === 'mi') {
             distance *= 1.09361;
             if (distance > 1760) distanceStr = L._('{distance} miles', {distance: (distance / 1760).toFixed(2)});
-            else distanceStr = L._('{distance} yd', {distance: Math.ceil(distance)});
+            else distanceStr = L._('{distance} yd', {distance: distance.toFixed(1)});
         } else if (unit === 'nm') {
             distance /= 1852;
             distanceStr = L._('{distance} NM', {distance: Math.ceil(distance)});
         } else {
             if (distance > 100000) distanceStr = L._('{distance} km', {distance: Math.ceil(distance / 1000)});
             else if (distance > 1000) distanceStr = L._('{distance} km', {distance: (distance / 1000).toFixed(2)});
-            else distanceStr = L._('{distance} m', {distance: Math.ceil(distance)});
+            else distanceStr = L._('{distance} m', {distance: distance.toFixed(1)});
         }
 
         return distanceStr;


### PR DESCRIPTION
I added rounding to on decimal after the point to increase accuracy in really far zoomed in setups. Tested it on my instance (see umap.dmho.de) and it works great.